### PR TITLE
feat: add keypad numbers to correct answer

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "ccv-bot@brown.edu",
     "url": "ccv.brown.edu"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "private": true,
   "main": "public/electron.js",

--- a/src/lib/rt-categorize-html.js
+++ b/src/lib/rt-categorize-html.js
@@ -116,17 +116,13 @@ export function rt_categorize_html() {
 
     // create response function
     var after_response = function(info) {
-
       // kill any remaining setTimeout handlers
       jsPsych.pluginAPI.clearAllTimeouts();
 
       // clear keyboard listener
       jsPsych.pluginAPI.cancelAllKeyboardResponses();
 
-      var correct = false;
-      if (trial.key_answer === info.key) {
-        correct = true;
-      }
+      const correct = trial.key_answer === info.key - 96 || trial.key_answer === info.key - 48;
 
       // save data
       trial_data = {

--- a/src/trials/interference.js
+++ b/src/trials/interference.js
@@ -10,21 +10,12 @@ const interference = (trial) => {
     type: 'rt-categorize-html',
     trial_duration: 1250,
     on_load: () => pdSpotEncode(code),
-    key_answer: 48+trial.Correct,
+    key_answer: trial.Correct,
     show_stim_with_feedback: false,
     feedback_duration: 2000,
     timeout_message: interferenceTrial(lang.prompt.too_slow, true) + photodiodeGhostBox(),
     stimulus: stimulus,
     response_ends_trial: true,
-    on_finish: (data) => {
-      if (data.key_press !== null) {
-        data.correct = trial.Correct === data.key_press - 48;
-      }
-      else {
-        data.correct = false;
-      }
-      data.code = data.key_press - 48
-    }
   }
 }
 


### PR DESCRIPTION
The data json changes a bit with this.
The `code` field, which was 1,2,3 corresponding to the correct answer is gone, and that number is in `key_answer` now. The `key_answer` from before, which was 48,49,50 corresponding to the right number key is also gone.